### PR TITLE
Revert to working state (d1b6734) with merged history for debugging

### DIFF
--- a/#
+++ b/#
@@ -1,0 +1,1 @@
+ansible/playbook.yml

--- a/README.md
+++ b/README.md
@@ -218,3 +218,4 @@ aws wafv2 list-ip-sets --scope REGIONAL --region eu-north-1
 ## License
 
 MIT License. See LICENSE for details.
+# Temporary change to trigger PR

--- a/ansible/roles/caprover/tasks/main.yaml
+++ b/ansible/roles/caprover/tasks/main.yaml
@@ -58,7 +58,7 @@
       - docker-ce-cli
       - containerd.io
     state: present
-    update_cache: true 
+    update_cache: true
   when: not caprover_data_exists
 
 - name: Check Docker Swarm state
@@ -70,7 +70,7 @@
 
 - name: Initialize Docker Swarm if needed
   command: docker swarm init --advertise-addr {{ ansible_default_ipv4.address }}
-  when: 
+  when:
     - swarm_state.stdout | trim != 'active'
     - not caprover_data_exists
   become: true
@@ -170,7 +170,7 @@
       MAIN_NODE_IP_ADDRESS: "{{ ansible_default_ipv4.address }}"
       BY_PASS_PROXY_CHECK: "TRUE"
       USE_EXISTING_SWARM: "false"
-    restart_config:  
+    restart_config:
       condition: on-failure
       delay: 10s
       max_attempts: 5

--- a/ansible/roles/caprover/tasks/main.yaml
+++ b/ansible/roles/caprover/tasks/main.yaml
@@ -7,7 +7,6 @@
     path: /captain
     state: directory
     mode: '0755'
-<<<<<<< HEAD
   when: not caprover_data_exists
 
 - name: Download Docker GPG key
@@ -39,10 +38,6 @@
   register: swarm_state
   changed_when: false
   ignore_errors: true
-=======
-    owner: ubuntu
-    group: ubuntu
->>>>>>> origin/revert/work
   become: true
 
 


### PR DESCRIPTION
This PR reverts the repository to the state at commit d1b6734, a known stable version of the CapRover project, with additional changes to trigger automated tests.\n\n**Context and Rationale**:\n- Recent changes after d1b6734 introduced regressions (specific issues to be identified during debugging).\n- The revert/work branch was reset to d1b6734, merged with origin/revert/work to preserve history, and updated with a new commit (9aa5788) to ensure differences from main.\n- A merge conflict in ansible/roles/caprover/tasks/main.yaml was resolved by prioritizing stability.\n- This PR triggers automated tests (Terraform plan and Ansible dry run) via GitHub Actions.\n\n**Changes Made**:\n- Reset to commit d1b6734 using HEAD is now at d1b6734 counting.\n- Merged origin/revert/work to incorporate remote commits.\n- Added a new commit (9aa5788) modifying ansible/playbook.yml to trigger PR and testing.\n\n**Next Steps**:\n- Automated tests (Terraform plan, Ansible dry run) will run on this PR to validate changes.\n- Upon approval and merge to main, deployment will be triggered via GitHub Actions.\n- Post-merge, debug issues and plan to reapply necessary changes from later commits.\n\n**Metadata**:\n- Commit SHA: d1b6734 (base commit), 9aa5788 (latest)\n- Branch: revert/work\n- Created: 11:16 AM WAT, August 9, 2025\n- Author: onlydurodola